### PR TITLE
Cypress v10 test

### DIFF
--- a/config/injectVariablesInHTML.ts
+++ b/config/injectVariablesInHTML.ts
@@ -1,11 +1,21 @@
-import { sync, ReplaceInFileConfig } from "replace-in-file";
+import { sync } from "replace-in-file";
 
-export default (options: ReplaceInFileConfig) => {
+type InjectVariablesInHTMLConfig = {
+  files: string | string[];
+  variables: string[];
+}
+export default (options: InjectVariablesInHTMLConfig) => {
+  const from = options.variables.map((v) => new RegExp(v, "g"));
+  const to = options.variables.map((v) => process.env[v.replace(/%/g, "")]);
   return {
     name: "injectVariablesInHTML",
     writeBundle: async () => {
       try {
-        sync(options);
+        sync({
+          files: options.files,
+          from,
+          to
+        });
       } catch (error) {
         console.error("Error occurred:", error);
       }

--- a/cypress/integration/00announcements.ts
+++ b/cypress/integration/00announcements.ts
@@ -1,14 +1,10 @@
 describe("Announcement overlays", () => {
-  before(() => {
-    cy.login();
-  });
-
   beforeEach(() => {
-    cy.preserveCookies();
+    cy.clearCookie("This is an important notification");
+    cy.visit("/");
   });
 
   it("Displays a welcome modal only when you first visit spruce", () => {
-    cy.visit("/");
     cy.dataCy("welcome-modal").should("exist");
     cy.dataCy("close-welcome-modal").click();
     cy.visit("/");

--- a/cypress/integration/404.ts
+++ b/cypress/integration/404.ts
@@ -1,6 +1,5 @@
 describe("404 Page", () => {
   it("Displays 404 page for routes that do not exist when user is logged in.", () => {
-    cy.login();
     cy.visit("/i-still-dont-exist");
     cy.dataCy("404").should("exist");
     cy.visit("/patch/5e4ff3abe3c3317e352062e4");

--- a/cypress/integration/auth.ts
+++ b/cypress/integration/auth.ts
@@ -1,5 +1,6 @@
 describe("Auth", () => {
   it("Unauthenticated user is redirected to login page after visiting a private route", () => {
+    cy.clearCookie("mci-token");
     cy.visit("/version/123123");
     cy.url().should("include", "/login");
   });

--- a/cypress/integration/banners/github_username_banner.ts
+++ b/cypress/integration/banners/github_username_banner.ts
@@ -1,12 +1,4 @@
 describe("Github username banner", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("should show the banner on the my patches page if user doesn't have a github username", () => {
     cy.visit("/");
     cy.dataCy("github-username-banner").should("exist");

--- a/cypress/integration/banners/slack_notification_banner.ts
+++ b/cypress/integration/banners/slack_notification_banner.ts
@@ -4,14 +4,10 @@ const slackNotificationBanner = "slack-notification-banner";
 const slackUsername = "username";
 
 describe("Slack notification banner", () => {
-  beforeEach(() => {
-    cy.login();
-    cy.visit("/");
-  });
-  afterEach(() => {
-    cy.clearCookies();
-  });
   it("shows up across the app if user has not set slack notification settings", () => {
+    cy.clearCookie("has-closed-slack-banner");
+
+    cy.visit("/");
     cy.dataCy(slackNotificationBanner).should("exist");
 
     cy.visit("/version/5ecedafb562343215a7ff297/tasks");
@@ -34,6 +30,11 @@ describe("Slack notification banner", () => {
   });
 
   it("does not show up after user has entered their username and clicks 'save'", () => {
+    cy.clearCookie("has-closed-slack-banner");
+
+    cy.visit("/version/5ecedafb562343215a7ff297/tasks");
+
+    cy.dataCy(slackNotificationBanner).should("be.visible");
     cy.dataCy("subscribe-to-notifications").click();
     cy.dataCy("slack-username-input").type(slackUsername);
     cy.get(popconfirmYesClassName).click();

--- a/cypress/integration/breadcrumbs.ts
+++ b/cypress/integration/breadcrumbs.ts
@@ -1,10 +1,4 @@
 describe("Viewing a patch", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   describe("Viewing a users own patch", () => {
     before(() => {
       cy.visit(
@@ -48,13 +42,9 @@ describe("Viewing a patch", () => {
 
 describe("Viewing a mainline commit", () => {
   before(() => {
-    cy.login();
     cy.visit(
       "/task/evergreen_ubuntu1604_test_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
     );
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
   });
   it("Shows the commit hash", () => {
     cy.dataCy("bc-version").should("include.text", "5e823e1");

--- a/cypress/integration/commit_queue.ts
+++ b/cypress/integration/commit_queue.ts
@@ -12,13 +12,6 @@ const COMMIT_QUEUE_ROUTE_4 = `/commit-queue/${commitQueue.id4}`;
 const COMMIT_QUEUE_ROUTE_PR = `/commit-queue/${commitQueue.id5}`;
 
 describe("commit queue page", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe(COMMIT_QUEUE_ROUTE_1, () => {
     before(() => {
       cy.visit(COMMIT_QUEUE_ROUTE_1);

--- a/cypress/integration/host/host_buttons.ts
+++ b/cypress/integration/host/host_buttons.ts
@@ -1,11 +1,6 @@
 describe("Host page restart jasper, reprovision, and update host status buttons", () => {
   before(() => {
-    cy.login();
     cy.visit("/host/i-0d0ae8b83366d22be");
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
   });
   it("Should show a toast when jasper restarted", () => {
     cy.dataCy("restart-jasper-button").click();

--- a/cypress/integration/host/host_core.ts
+++ b/cypress/integration/host/host_core.ts
@@ -1,12 +1,4 @@
 describe("Host load page with nonexistent host", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should show an error message when navigating to a nonexistent host id", () => {
     cy.visit("host/not-real");
     cy.validateToast("error");
@@ -14,14 +6,6 @@ describe("Host load page with nonexistent host", () => {
 });
 
 describe("Host page title is displayed ", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("title shows the host name", () => {
     cy.visit(`host/macos-1014-68.macstadium.build.10gen`);
     cy.dataCy("page-title").should(

--- a/cypress/integration/host/host_events.ts
+++ b/cypress/integration/host/host_events.ts
@@ -3,14 +3,6 @@ import { clickOnPageSizeBtnAndAssertURLandTableSize } from "../../utils";
 const pathWithEvents = `/host/i-0f81a2d39744003dd`;
 
 describe("Host events", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("host events display the correct text", () => {
     cy.visit(pathWithEvents);
     clickOnPageSizeBtnAndAssertURLandTableSize(100, dataCy);

--- a/cypress/integration/host/host_sidebar.ts
+++ b/cypress/integration/host/host_sidebar.ts
@@ -2,14 +2,6 @@ const pathWithTask = `/host/i-0fb9fe0592ea3815`;
 const pathNoTask = `/host/macos-1014-68.macstadium.build.10gen`;
 
 describe("Host page title and sidebar ", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("title shows the host name", () => {
     cy.visit(pathNoTask);
     cy.dataCy("page-title").should(

--- a/cypress/integration/hosts/host_filtering.ts
+++ b/cypress/integration/hosts/host_filtering.ts
@@ -1,5 +1,3 @@
-import { aliasQuery, GQL_URL } from "../../utils/graphql-test-utils";
-
 const hostsRoute = "/hosts";
 
 const tableRow = "tr.ant-table-row";
@@ -12,7 +10,7 @@ const ownerParam = "startedBy";
 
 const idFilter = "i-0d0ae8b83366d22";
 const distroFilter = "macos-1014";
-const statusesFilter = "running,provisioning";
+const statusesFilter = "running";
 const currentTaskIdFilter =
   "mongodb_mongo_v3.6_debian92_sharding_auth_bc405c72dce4714da604810cdc90c132bd5fbaa1_20_07_20_17_39_20";
 const ownerFilter = "mci";
@@ -42,14 +40,8 @@ const filterTests = [
     param: statusesParam,
     filterIconDataCy: "statuses-filter",
     filterValue: statusesFilter,
-    filterUrlParam: `limit=50&page=0&${statusesParam}=${statusesFilter}`,
+    filterUrlParam: `${statusesParam}=${statusesFilter}`,
     expectedIds: [
-      "i-06f80fa6e28f93b",
-      "i-06f80fa6e28f93b7",
-      "i-06f80fa6e28f93b7d",
-      "i-0fb9fe0592ea381",
-      "i-0fb9fe0592ea3815",
-      "i-0fb9fe0592ea38150",
       "16326bd716fd4ad5845710c479c79e86c66b61bcef8ebbe7fc38dfc36fab512e",
       "1694cfe1eac28b3316339f6276021afcb2a07bcd21a266405835fd039557ea2d",
       "4b332e12790a585a0c7cbaf1650674f408117cf6134679c9e5f2e96cadd07923",
@@ -60,21 +52,6 @@ const filterTests = [
       "build10.ny.cbi.10gen",
       "build10.ny.cbi.10gen.c",
       "build10.ny.cbi.10gen.cc",
-      "c04d193c4de174376167746bc268426a4085bffb364c4740e0564ca3eeee6875",
-      "i-04ade558e1e26b0ad",
-      "i-092593689871a50dc",
-      "i-0a5b8aa85c469e35d",
-      "i-0d0ae8b83366d22",
-      "i-0d0ae8b83366d22b",
-      "i-0d0ae8b83366d22be",
-      "i-0f81a2d39744003",
-      "i-0f81a2d39744003d",
-      "i-0f81a2d39744003dd",
-      "rhel71-ppc-1.pic.build.10gen.c",
-      "rhel71-ppc-1.pic.build.10gen.cc",
-      "ubuntu1604-ppc-1.pic.build.10gen",
-      "ubuntu1604-ppc-1.pic.build.10gen.c",
-      "ubuntu1604-ppc-1.pic.build.10gen.cc",
     ],
   },
   {
@@ -104,170 +81,57 @@ const filterTests = [
       "macos-1014-68.macstadium.build.10gen.c",
       "macos-1014-68.macstadium.build.10gen.cc",
       "ubuntu1804-ppc-3.pic.build.10gen",
-      "ubuntu1804-ppc-3.pic.build.10gen.c",
-      "ubuntu1804-ppc-3.pic.build.10gen.cc",
-      "build10.ny.cbi.10gen",
-      "build10.ny.cbi.10gen.c",
-      "build10.ny.cbi.10gen.cc",
-      "i-0d0ae8b83366d22",
-      "i-0d0ae8b83366d22b",
-      "i-0d0ae8b83366d22be",
-      "i-0f81a2d39744003",
-      "i-0f81a2d39744003d",
-      "i-0f81a2d39744003dd",
-      "rhel71-ppc-1.pic.build.10gen",
-      "rhel71-ppc-1.pic.build.10gen.c",
-      "rhel71-ppc-1.pic.build.10gen.cc",
-      "ubuntu1604-ppc-1.pic.build.10gen",
-      "ubuntu1604-ppc-1.pic.build.10gen.c",
-      "ubuntu1604-ppc-1.pic.build.10gen.cc",
     ],
   },
 ];
 
-describe("Hosts page filtering from URL", () => {
+describe("Hosts page filtering from table filters", () => {
   before(() => {
-    cy.login();
+    cy.visit(`${hostsRoute}?page=0`);
   });
-
   beforeEach(() => {
-    cy.preserveCookies();
+    cy.dataCy("hosts-table").should("be.visible");
+    cy.dataCy("hosts-table").should("have.attr", "data-loading", "false");
   });
 
-  it("Calculates number of pages based on total hosts count if no filters", () => {
-    cy.visit(hostsRoute);
-    cy.get(".ant-pagination-simple-pager")
-      .should("have.attr", "title")
-      .and("eq", "1/4");
-  });
-
-  it("Calculates number of pages based on filtered hosts count if hosts are filtered", () => {
-    cy.visit(`${hostsRoute}?${idParam}=${idFilter}`);
-    cy.get(".ant-pagination-simple-pager")
-      .should("have.attr", "title")
-      .and("eq", "1/1");
-  });
-
-  filterTests.forEach(({ param, filterUrlParam, expectedIds }) => {
-    it(`Filters by ${param} if ${param} url query param exists`, () => {
-      cy.visit(`${hostsRoute}?${filterUrlParam}`);
-      cy.get(tableRow).each(($el, index) =>
-        cy.wrap($el).contains(expectedIds[index])
-      );
-    });
-  });
-});
-
-describe(
-  "Hosts page filtering from table filters",
-  { scrollBehavior: false },
-  () => {
-    before(() => {
-      cy.login();
-    });
-
-    beforeEach(() => {
-      cy.preserveCookies();
-      cy.setCookie(bannerCookie, "true");
-      cy.intercept("POST", GQL_URL, (req) => {
-        aliasQuery(req, "Hosts");
-      });
-      cy.visit(`${hostsRoute}?limit=100&page=0`);
-      cy.wait("@gqlHostsQuery");
-      cy.dataCy("sitewide-banner").should("not.exist");
-      cy.dataCy("hosts-table").should("be.visible");
-      cy.dataCy("hosts-table").should("not.have.attr", "data-loading", "true");
-      cy.dataCy(distroFilterIconDataCy)
-        .should("be.visible")
-        .should("not.be.disabled");
-    });
-
-    it("Filters hosts with input value when Enter key is pressed", () => {
-      cy.dataCy(distroFilterIconDataCy).scrollIntoView().click();
-      cy.dataCy(`${distroFilterIconDataCy}-wrapper`).within(() => {
-        cy.dataCy("input-filter").type("centos6-perf").type("{enter}");
-      });
-
-      cy.get(tableRow).each(($el, index) =>
-        cy
-          .wrap($el)
-          .contains(
-            [
-              "16326bd716fd4ad5845710c479c79e86c66b61bcef8ebbe7fc38dfc36fab512e",
-              "1694cfe1eac28b3316339f6276021afcb2a07bcd21a266405835fd039557ea2d",
-              "4b332e12790a585a0c7cbaf1650674f408117cf6134679c9e5f2e96cadd07923",
-              "6e331e02aaaebba422d1f1d2dbd3e64f01776b84c68c672ea680e4b81b0719bb",
-              "7f909d47566126bd39a05c1a5bd5d111c2e68de3830a8be414c18c231a47f4fc",
-              "a99b50cd37b012c53db7207e4ba8b52989aefab551176c07962cea979abcc479",
-              "b700d10f21a5386c827251a029dd931b5ea910377e0bb93f3393b17fb9bdbd08",
-              "build10.ny.cbi.10gen",
-              "build10.ny.cbi.10gen.c",
-              "build10.ny.cbi.10gen.cc",
-              "c04d193c4de174376167746bc268426a4085bffb364c4740e0564ca3eeee6875",
-              "i-0a5b8aa85c469e35d",
-            ][index]
-          )
-      );
-    });
-
-    it("Trims the whitespace from filter input values", () => {
-      cy.dataCy(distroFilterIconDataCy).scrollIntoView().click();
-
-      cy.dataCy(`${distroFilterIconDataCy}-wrapper`).within(() => {
-        cy.dataCy("input-filter")
-          .type("      centos6-perf     ")
-          .type("{enter}");
-      });
-
-      cy.get(tableRow).each(($el, index) =>
-        cy
-          .wrap($el)
-          .contains(
-            [
-              "16326bd716fd4ad5845710c479c79e86c66b61bcef8ebbe7fc38dfc36fab512e",
-              "1694cfe1eac28b3316339f6276021afcb2a07bcd21a266405835fd039557ea2d",
-              "4b332e12790a585a0c7cbaf1650674f408117cf6134679c9e5f2e96cadd07923",
-              "6e331e02aaaebba422d1f1d2dbd3e64f01776b84c68c672ea680e4b81b0719bb",
-              "7f909d47566126bd39a05c1a5bd5d111c2e68de3830a8be414c18c231a47f4fc",
-              "a99b50cd37b012c53db7207e4ba8b52989aefab551176c07962cea979abcc479",
-              "b700d10f21a5386c827251a029dd931b5ea910377e0bb93f3393b17fb9bdbd08",
-              "build10.ny.cbi.10gen",
-              "build10.ny.cbi.10gen.c",
-              "build10.ny.cbi.10gen.cc",
-              "c04d193c4de174376167746bc268426a4085bffb364c4740e0564ca3eeee6875",
-              "i-0a5b8aa85c469e35d",
-            ][index]
-          )
-      );
-    });
-
-    filterTests.forEach(({ param, filterIconDataCy, filterValue }) => {
+  filterTests.forEach(
+    ({ param, filterIconDataCy, filterValue, filterUrlParam, expectedIds }) => {
       it(`Filters hosts using table filter dropdowns for ${param}`, () => {
+        cy.dataCy(filterIconDataCy).should("be.visible");
         cy.dataCy(filterIconDataCy).click();
         cy.dataCy(`${filterIconDataCy}-wrapper`).should("be.visible");
-        cy.dataCy(`${filterIconDataCy}-wrapper`).within(() => {
-          if (param === statusesParam) {
-            cy.getInputByLabel("Running").click({ force: true });
-          } else if (param === currentTaskIdParam) {
-            // do this for really long text because otherwise cypress times out while typing and fails
-            const subString = filterValue.substring(0, filterValue.length - 1);
-            const lastChar = filterValue.slice(-1);
+        if (param === statusesParam) {
+          cy.getInputByLabel("Running").check({ force: true });
+        } else {
+          cy.dataCy("input-filter").should("be.visible");
+          cy.dataCy("input-filter")
+            .should("be.focused")
+            .focus()
+            .type(`${filterValue}`, { scrollBehavior: false })
+            .type("{enter}");
+        }
+        cy.location("search").should("contain", filterUrlParam);
+        cy.get(".ant-dropdown").should("not.exist");
+        cy.dataCy("hosts-table").should("have.attr", "data-loading", "false");
 
-            cy.dataCy("input-filter")
-              .as("currentTask")
-              .invoke("val", subString)
-              .trigger("input");
-
-            cy.get("@currentTask").type(lastChar).type(`{enter}`);
-          } else {
-            cy.dataCy("input-filter")
-              .should("be.visible")
-              .should("not.be.disabled");
-            cy.dataCy("input-filter").type(filterValue).type(`{enter}`);
-          }
+        expectedIds.forEach((id) => {
+          cy.get(tableRow).contains(id).should("be.visible");
         });
+
+        cy.dataCy(filterIconDataCy).should("be.visible");
+        cy.dataCy(filterIconDataCy).click();
+        cy.dataCy(`${filterIconDataCy}-wrapper`).should("be.visible");
+        if (param === statusesParam) {
+          cy.getInputByLabel("Running").uncheck({ force: true });
+        } else {
+          cy.dataCy("input-filter").should("be.visible");
+          cy.dataCy("input-filter")
+            .should("be.focused")
+            .focus()
+            .clear()
+            .type("{enter}");
+        }
       });
-    });
-    const bannerCookie = "This is an important notification";
-  }
-);
+    }
+  );
+});

--- a/cypress/integration/hosts/hosts_page_default.ts
+++ b/cypress/integration/hosts/hosts_page_default.ts
@@ -2,12 +2,7 @@ const taskId =
   "mongo_tools_ubuntu1604_qa_dump_restore_with_archiving_current_patch_b7227e1b7aeaaa6283d53b32fc03968a46b19c2d_5f15ad3c3627e07772ab2d01_20_07_20_14_42_05";
 
 describe("Hosts Page Default", () => {
-  before(() => {
-    cy.login();
-  });
-
   beforeEach(() => {
-    cy.preserveCookies();
     cy.visit("/hosts");
   });
 

--- a/cypress/integration/hosts/hosts_pagination.ts
+++ b/cypress/integration/hosts/hosts_pagination.ts
@@ -3,14 +3,6 @@ import { defaultHostsFirstPage } from "./hosts_page_default";
 const tableRow = "tr.ant-table-row";
 
 describe("Hosts Page", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("URL query parameters determine pagination values", () => {
     cy.visit("/hosts?limit=10&page=1");
 

--- a/cypress/integration/hosts/hosts_sorting.ts
+++ b/cypress/integration/hosts/hosts_sorting.ts
@@ -153,14 +153,6 @@ const sortDirectionTests = [
 ];
 
 describe("Hosts page sorting", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Status sorter is selected by default if no sort params in url", () => {
     cy.visit(hostsRoute);
     cy.get(".cy-task-table-col-STATUS").within(() => {

--- a/cypress/integration/hosts/select_hosts.ts
+++ b/cypress/integration/hosts/select_hosts.ts
@@ -1,12 +1,7 @@
 const hostsRoute = "/hosts";
 
 describe("Select hosts in hosts page table", () => {
-  before(() => {
-    cy.login();
-  });
-
   beforeEach(() => {
-    cy.preserveCookies();
     cy.visit(`${hostsRoute}?distroId=ubuntu1604-large&page=0&statuses=running`);
     cy.dataCy("hosts-table").should("exist");
     cy.dataCy("hosts-table").should("not.have.attr", "data-loading", "true");

--- a/cypress/integration/hosts/update_status_modal.ts
+++ b/cypress/integration/hosts/update_status_modal.ts
@@ -1,11 +1,6 @@
 const hostsRoute = "/hosts";
 
 describe("Update Status Modal", () => {
-  before(() => {
-    cy.login();
-    cy.preserveCookies();
-  });
-
   beforeEach(() => {
     cy.visit(`${hostsRoute}?limit=100&page=0`);
     cy.dataCy("hosts-table").should("exist");

--- a/cypress/integration/job_logs.ts
+++ b/cypress/integration/job_logs.ts
@@ -1,14 +1,6 @@
 import { clickOnPageSizeBtnAndAssertURLandTableSize } from "../utils";
 
 describe("Job Logs", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("renders page title and test log links when groupId is in URL", () => {
     cy.visit(`job-logs/${taskId}/${execution}/${groupId}`);
     cy.dataCy("task-link").contains(taskId);

--- a/cypress/integration/myPatches/my_patches.ts
+++ b/cypress/integration/myPatches/my_patches.ts
@@ -9,14 +9,6 @@ const BOB_HICKS_PATCHES_ROUTE = "/user/bob.hicks/patches";
 const REGULAR_USER_PATCHES_ROUTE = "/user/regular/patches";
 
 describe("My Patches Page", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Redirects user to user patches route from `/user/:id`", () => {
     cy.visit("user/chicken");
     cy.location().should((loc) =>
@@ -119,7 +111,6 @@ describe("My Patches Page", () => {
 
   describe("Clicking on status checkbox requests and renders patches for that status", () => {
     beforeEach(() => {
-      cy.preserveCookies();
       cy.dataCy("my-patch-status-select").click();
     });
     before(() => {

--- a/cypress/integration/myPatches/patchCard/dropdown_menu.ts
+++ b/cypress/integration/myPatches/patchCard/dropdown_menu.ts
@@ -9,9 +9,6 @@ const getPatchCardByDescription = (description: string) =>
   cy.dataCy("patch-card").filter(`:contains(${description})`);
 
 describe("Dropdown Menu of Patch Actions", () => {
-  before(() => {
-    cy.login();
-  });
   beforeEach(() => {
     cy.preserveCookies();
     cy.visit("/");

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -1,5 +1,3 @@
-import { aliasQuery, GQL_URL } from "../utils/graphql-test-utils";
-
 const PATCH_ID = "5e4ff3abe3c3317e352062e4";
 const USER_ID = "admin";
 const SPRUCE_URLS = {
@@ -54,11 +52,7 @@ describe("Nav Bar", () => {
   it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
     cy.clearCookie("mci-project-cookie");
 
-    cy.intercept("POST", GQL_URL, (req) => {
-      aliasQuery(req, "GetSpruceConfig");
-    });
     cy.visit(SPRUCE_URLS.userPatches);
-    cy.wait("@gqlGetSpruceConfigQuery");
     cy.dataCy("auxiliary-dropdown-link").click();
     cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/evergreen/patches");

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -13,13 +13,6 @@ const LEGACY_URLS = {
   distros: `/distros`,
 };
 describe("Nav Bar", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should have a nav bar linking to the proper page on the legacy UI", () => {
     cy.visit(SPRUCE_URLS.version);
     cy.dataCy("legacy-ui-link").should("exist");

--- a/cypress/integration/nav_bar.ts
+++ b/cypress/integration/nav_bar.ts
@@ -51,9 +51,13 @@ describe("Nav Bar", () => {
   });
   it("Nav Dropdown should link to patches page of default project in SpruceConfig if cookie does not exist", () => {
     cy.clearCookie("mci-project-cookie");
-
     cy.visit(SPRUCE_URLS.userPatches);
     cy.dataCy("auxiliary-dropdown-link").click();
+    cy.dataCy("auxiliary-dropdown-project-patches").should(
+      "have.attr",
+      "href",
+      "/project/evergreen/patches"
+    );
     cy.dataCy("auxiliary-dropdown-project-patches").click();
     cy.location("pathname").should("eq", "/project/evergreen/patches");
   });

--- a/cypress/integration/page_tabs.ts
+++ b/cypress/integration/page_tabs.ts
@@ -1,12 +1,4 @@
 describe("Tabs", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("Patches page", () => {
     it("Defaults to the task tab and applies default sorts", () => {
       cy.visit(patchRoute);

--- a/cypress/integration/preferences/public_key_management.ts
+++ b/cypress/integration/preferences/public_key_management.ts
@@ -3,14 +3,6 @@ import { popconfirmYesClassName } from "../../utils/popconfirm";
 const route = "/preferences/publickeys";
 
 describe("Public Key Management Page", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("Public keys list", () => {
     before(() => {
       cy.visit(route);

--- a/cypress/integration/preferences/public_key_management.ts
+++ b/cypress/integration/preferences/public_key_management.ts
@@ -39,20 +39,20 @@ describe("Public Key Management Page", () => {
 
     it("Error messages go away after typing valid input", () => {
       cy.dataCy("key-name-input").type(keyName3);
-      cy.dataCy("key-value-input").paste("ssh-dss someHash");
+      cy.dataCy("key-value-input").type("ssh-dss someHash", { delay: 0 });
       cy.dataCy("error-message").should("have.length", 0);
     });
 
     it("Should include the public in the public key list after adding", () => {
       cy.dataCy("key-value-input").clear();
-      cy.dataCy("key-value-input").paste(pubKey);
+      cy.dataCy("key-value-input").type(pubKey, { delay: 0 });
       cy.dataCy("save-key-button").click();
       cy.dataCy("table-key-name").first().contains(keyName3);
     });
 
     it("Should show an error if the key name already exists", () => {
       cy.dataCy("add-key-button").click();
-      cy.dataCy("key-name-input").type(keyName3);
+      cy.dataCy("key-name-input").type(keyName3, { delay: 0 });
       cy.dataCy("error-message").first().contains(err3);
     });
 
@@ -74,21 +74,24 @@ describe("Public Key Management Page", () => {
       cy.dataCy("key-name-input").clear();
       cy.dataCy("key-name-input").type(keyName4);
       cy.dataCy("key-value-input").clear();
-      cy.dataCy("key-value-input").paste(pubKey2);
+
+      cy.dataCy("key-value-input").type(pubKey2, { delay: 0 });
       cy.dataCy("save-key-button").click();
       cy.dataCy("key-edit-modal").should("not.be.visible");
       cy.dataCy("table-key-name").first().contains(keyName4);
       cy.dataCy("edit-btn").first().click();
       cy.dataCy("key-name-input").should("have.value", keyName4);
       cy.dataCy("key-value-input").should("have.value", pubKey2);
-      cy.dataCy("key-value-input").paste(pubKey3);
+      cy.dataCy("key-value-input").clear();
+      cy.dataCy("key-value-input").type(pubKey3, { delay: 0 });
       cy.dataCy("save-key-button").click();
       cy.dataCy("key-edit-modal").should("not.be.visible");
       cy.dataCy("table-key-name").first().contains(keyName4);
       cy.dataCy("edit-btn").first().click();
       cy.dataCy("key-name-input").should("have.value", keyName4);
       cy.dataCy("key-value-input").should("have.value", pubKey3);
-      cy.dataCy("key-value-input").paste(pubKey4);
+      cy.dataCy("key-value-input").clear();
+      cy.dataCy("key-value-input").type(pubKey4, { delay: 0 });
       cy.dataCy("save-key-button").click();
       cy.dataCy("key-edit-modal").should("not.be.visible");
       cy.dataCy("table-key-name").first().contains(keyName4);
@@ -107,7 +110,7 @@ describe("Public Key Management Page", () => {
       cy.visit(route);
       cy.dataCy("add-key-button").click();
       cy.dataCy("key-name-input").type("rsioeantarsn");
-      cy.dataCy("key-value-input").paste("ssh-rsa ");
+      cy.dataCy("key-value-input").type("ssh-rsa ", { delay: 0 });
       cy.dataCy("save-key-button").click();
       cy.validateToast("error");
     });

--- a/cypress/integration/preferences/user_preferences.ts
+++ b/cypress/integration/preferences/user_preferences.ts
@@ -5,13 +5,6 @@ const tabNames = {
   cli: "/cli",
 };
 describe("user preferences pages", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("visiting /preferences should redirect to the profile tab", () => {
     cy.visit(baseRoute);
     cy.url().should("include", `${baseRoute}${tabNames.profile}`);

--- a/cypress/integration/projectHealth/commits.ts
+++ b/cypress/integration/projectHealth/commits.ts
@@ -3,9 +3,6 @@ describe("commits page", () => {
     cy.login();
     cy.visit("/commits/spruce");
   });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("visiting the commits page for the first time should show a welcome modal", () => {
     cy.dataCy("welcome-modal").should("be.visible");
     cy.dataCy("close-welcome-modal").click();

--- a/cypress/integration/projectHealth/route.ts
+++ b/cypress/integration/projectHealth/route.ts
@@ -1,10 +1,4 @@
 describe("Mainline Commits page route", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("Should default to the project saved in the mci-project-cookie when a project does not exist in the url.", () => {
     cy.setCookie("mci-project-cookie", "spruce");
     cy.visit("/commits");

--- a/cypress/integration/projectHealth/taskHistory.ts
+++ b/cypress/integration/projectHealth/taskHistory.ts
@@ -3,9 +3,6 @@ describe("task history", () => {
     cy.login();
     cy.setCookie("has-closed-slack-banner", "true");
   });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
 
   it("link from task page should link to the commit and scroll to it", () => {
     cy.visit(`/task/${taskId}`);

--- a/cypress/integration/projectHealth/variantHistory.ts
+++ b/cypress/integration/projectHealth/variantHistory.ts
@@ -1,7 +1,4 @@
 describe("variant history", () => {
-  before(() => {
-    cy.login();
-  });
   beforeEach(() => {
     cy.viewport(1000, 600);
     cy.preserveCookies();

--- a/cypress/integration/projectSettings/project_settings.ts
+++ b/cypress/integration/projectSettings/project_settings.ts
@@ -19,10 +19,6 @@ describe("Clicking on The Project Select Dropdown ", () => {
     cy.visit(destination);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Headers are clickable", () => {
     cy.dataCy("project-select").should("be.visible");
     cy.dataCy("project-select").click();
@@ -41,10 +37,6 @@ describe("Repo Settings", () => {
   before(() => {
     cy.login();
     cy.visit(destination);
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
   });
 
   it("Should not have the save button enabled on load", () => {
@@ -295,10 +287,6 @@ describe("Project Settings when not defaulting to repo", () => {
     cy.visit(destination);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should not have the save button enabled on load", () => {
     cy.dataCy("save-settings-button").should("be.disabled");
   });
@@ -497,10 +485,6 @@ describe("Project Settings when defaulting to repo", () => {
   before(() => {
     cy.login();
     cy.visit(destination);
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
   });
 
   describe("General Settings page", () => {
@@ -798,10 +782,6 @@ describe("Attaching Spruce to a repo", () => {
     cy.visit(destination);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Saves a new repo", () => {
     cy.dataCy("repo-input").clear().type("evergreen");
 
@@ -863,10 +843,6 @@ describe("Renaming the identifier", () => {
     cy.visit(destination);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Shows warning text when identifier is changed", () => {
     const warningText =
       "Updates made to the project identifier will change the identifier used for the CLI, inter-project dependencies, etc. Project users should be made aware of this change, as the old identifier will no longer work.";
@@ -892,10 +868,6 @@ describe("Duplicating a project with errors", () => {
   before(() => {
     cy.login();
     cy.visit(destination);
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
   });
 
   it("Shows the copy modal when the button and dropdown menu are clicked", () => {
@@ -924,10 +896,6 @@ describe("A project that has GitHub webhooks disabled", () => {
     cy.visit(destination);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Disables all interactive elements on the page", () => {
     cy.get("button").should("be.disabled");
     cy.get("input").should("be.disabled");
@@ -939,9 +907,6 @@ describe("Notifications", () => {
   before(() => {
     cy.login();
     cy.visit(destination);
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
   });
   it("shouldn't have any subscriptions defined", () => {
     cy.contains("No subscriptions are defined.").should("exist");

--- a/cypress/integration/spawn/host.ts
+++ b/cypress/integration/spawn/host.ts
@@ -25,14 +25,6 @@ const hostTaskId =
 const distroId = "ubuntu1604-small";
 
 describe("Navigating to Spawn Host page", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Visiting the spawn host page should display all of your spawned hosts", () => {
     cy.visit("/spawn/host");
     cy.get(hostTableRow).should("have.length", 2);

--- a/cypress/integration/spawn/route.ts
+++ b/cypress/integration/spawn/route.ts
@@ -1,12 +1,4 @@
 describe("Navigating to Spawn Host and Spawn Volume pages", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Navigating to /spawn will redirect to /spawn/host", () => {
     cy.visit("/spawn");
     cy.location("pathname").should("eq", "/spawn/host");

--- a/cypress/integration/spawn/volume.ts
+++ b/cypress/integration/spawn/volume.ts
@@ -1,12 +1,4 @@
 describe("Navigating to Spawn Volume page", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("Edit volume modal", () => {
     it("Clicking on 'Edit' should open the Edit Volume Modal", () => {
       cy.visit("/spawn/volume");

--- a/cypress/integration/subscription_modal.ts
+++ b/cypress/integration/subscription_modal.ts
@@ -10,13 +10,6 @@ const testSharedSubscriptionModalFunctionality = (
   type: string
 ) => {
   describe(description, () => {
-    before(() => {
-      cy.login();
-      cy.preserveCookies();
-    });
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
     it("Displays success toast after submitting a valid form and request succeeds", () => {
       openSubscriptionModal(route, dataCyToggleModalButton);
       cy.dataCy(dataCyModal).should("exist");

--- a/cypress/integration/task/aborted_task.ts
+++ b/cypress/integration/task/aborted_task.ts
@@ -1,12 +1,4 @@
 describe("Task page for an aborted task", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should link to failing task in task metadata should exist for aborted tasks", () => {
     cy.visit(
       "task/mongodb_mongo_main_enterprise_rhel_62_64_bit_dbtest_patch_0af9c85d7e2ba60f592f2d7a9a35217e254e59fb_5ee1efb3d1fe073e194e8b5c_20_06_11_08_48_06"

--- a/cypress/integration/task/annotations.ts
+++ b/cypress/integration/task/annotations.ts
@@ -14,10 +14,6 @@ describe("Task Annotation Tab", () => {
     cy.visit(taskRoute);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("annotations can be moved between lists", () => {
     cy.get(issuesTable).should("have.length", 1);
     cy.get(suspectedIssuesTable).should("have.length", 3);

--- a/cypress/integration/task/execution_task_table.ts
+++ b/cypress/integration/task/execution_task_table.ts
@@ -7,10 +7,6 @@ describe("Execution task table", () => {
     cy.visit(pathExecutionTasks);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should have a default sort order applied", () => {
     cy.location("search").should("contain", "sorts=STATUS%3AASC");
   });

--- a/cypress/integration/task/files_tables.ts
+++ b/cypress/integration/task/files_tables.ts
@@ -3,14 +3,6 @@ const FILES_ROUTE_WITHOUT_FILES =
   "/task/evergreen_ubuntu1604_test_model_commitqueue_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48/files ";
 
 describe("files table", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("File names under name column should link to a new tab", () => {
     cy.visit(FILES_ROUTE);
     cy.dataCy("fileLink").should("have.attr", "target", "_blank");

--- a/cypress/integration/task/select_execution.ts
+++ b/cypress/integration/task/select_execution.ts
@@ -1,12 +1,4 @@
 describe("Selecting Task Execution", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should take user to the latest execution if no execution is specified", () => {
     cy.visit(
       "/task/logkeeper_ubuntu_test_edd78c1d581bf757a880777b00685321685a8e67_16_10_20_21_58_58/logs"

--- a/cypress/integration/task/task-queue-position.ts
+++ b/cypress/integration/task/task-queue-position.ts
@@ -1,12 +1,4 @@
 describe("Task Queue Position", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Shows link to task queue if task is on queue", () => {
     cy.visit(
       "/task/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"

--- a/cypress/integration/task/task_actions.ts
+++ b/cypress/integration/task/task_actions.ts
@@ -1,15 +1,7 @@
 import { popconfirmYesClassName } from "../../utils/popconfirm";
 
 describe("Task Action Buttons", () => {
-  before(() => {
-    cy.login();
-  });
-
   describe("Based on the state of the task, some buttons should be disabled and others should be clickable. Clicking on buttons produces banners messaging if the action succeeded or failed.", () => {
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
-
     it("Schedule button should be disabled on a completed task", () => {
       cy.visit(tasks[1]);
       cy.dataCy("schedule-task").should("be.disabled");

--- a/cypress/integration/task/task_logs.ts
+++ b/cypress/integration/task/task_logs.ts
@@ -6,10 +6,6 @@ describe("task logs", () => {
     cy.visit(LOGS_ROUTE);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Should default to the  task logs page when logtype is not indicated in URL query param", () => {
     cy.dataCy("task-radio").should("be.checked");
   });

--- a/cypress/integration/task/task_route.ts
+++ b/cypress/integration/task/task_route.ts
@@ -1,12 +1,4 @@
 describe("Task Page Route", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("shouldn't get stuck in a redirect loop when visiting the task page and trying to navigate to a previous page", () => {
     cy.visit("/user/admin/patches");
     cy.visit(`/task/${tasks[1]}`);

--- a/cypress/integration/task/test_table.ts
+++ b/cypress/integration/task/test_table.ts
@@ -5,14 +5,6 @@ import {
 } from "../../utils";
 
 describe("Tests Table", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Test count should update to reflect filtered values", () => {
     cy.visit(TESTS_ROUTE);
 

--- a/cypress/integration/taskQueue/route.ts
+++ b/cypress/integration/taskQueue/route.ts
@@ -1,5 +1,3 @@
-import { aliasQuery, GQL_URL } from "../../utils/graphql-test-utils";
-
 describe("Task Queue", () => {
   it("Sets first distro in list as default if no distro in url", () => {
     cy.visit("/task-queue");
@@ -54,22 +52,14 @@ describe("Task Queue", () => {
     cy.get(".ant-table-row").should("have.length", 0);
   });
 
-  it(
-    "Scrolls to current task if taskId param in url",
-    { scrollBehavior: false },
-    () => {
-      cy.intercept("POST", GQL_URL, (req) => {
-        aliasQuery(req, "DistroTaskQueue");
-      });
-      cy.visit(
-        "/task-queue/osx-108/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
-      );
-      cy.wait("@gqlDistroTaskQueueQuery");
-      cy.dataCy("task-queue-table").should("exist");
-      cy.get(".ant-table-row-selected").should("exist");
-      cy.get(".ant-table-row-selected").contains("13").should("be.visible");
-    }
-  );
+  it("Scrolls to current task if taskId param in url", () => {
+    cy.visit(
+      "/task-queue/osx-108/evergreen_lint_lint_service_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48"
+    );
+    cy.dataCy("task-queue-table").should("exist");
+    cy.get(".ant-table-row-selected").should("exist");
+    cy.get(".ant-table-row-selected").contains("13").should("be.visible");
+  });
 
   it("Task links goes to Spruce for both patches and mainline commits", () => {
     cy.visit(

--- a/cypress/integration/taskQueue/route.ts
+++ b/cypress/integration/taskQueue/route.ts
@@ -1,14 +1,6 @@
 import { aliasQuery, GQL_URL } from "../../utils/graphql-test-utils";
 
 describe("Task Queue", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Sets first distro in list as default if no distro in url", () => {
     cy.visit("/task-queue");
 

--- a/cypress/integration/version/action_buttons.ts
+++ b/cypress/integration/version/action_buttons.ts
@@ -6,12 +6,6 @@ const mainlineCommit = "5e4ff3abe3c3317e352062e4";
 const versionPath = (id) => `/version/${id}`;
 
 describe("Action Buttons", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   describe("When viewing a patch build", () => {
     before(() => {
       cy.visit(versionPath(patch));

--- a/cypress/integration/version/downstream_tasks.ts
+++ b/cypress/integration/version/downstream_tasks.ts
@@ -2,14 +2,6 @@ const patchWithDownstreamTasks = "5f74d99ab2373627c047c5e5";
 const DOWNSTREAM_TASKS_ROUTE = `/version/${patchWithDownstreamTasks}/downstream-tasks`;
 
 describe("Downstream Tasks Tab", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Shows the child patches", () => {
     cy.visit(DOWNSTREAM_TASKS_ROUTE);
 

--- a/cypress/integration/version/patch_with_aborted_task.ts
+++ b/cypress/integration/version/patch_with_aborted_task.ts
@@ -1,8 +1,4 @@
 describe("Patch with aborted task", () => {
-  before(() => {
-    cy.login();
-  });
-
   it("Shows status `aborted` in task table for tasks that were aborted", () => {
     cy.visit("/version/5ee1efb3d1fe073e194e8b5c");
     cy.get(

--- a/cypress/integration/version/restart_modal.ts
+++ b/cypress/integration/version/restart_modal.ts
@@ -15,14 +15,6 @@ describe("Restarting a patch with Downstream Tasks", () => {
 });
 
 describe("Restarting a patch", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Clicking on the Restart button opens a patch restart modal", () => {
     cy.visit(path);
     cy.dataCy("version-restart-modal").should("not.exist");
@@ -95,12 +87,6 @@ describe("Restarting a patch", () => {
 });
 
 describe("Restarting mainline commits", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("should be able to restart scheduled mainline commit tasks", () => {
     cy.visit("/version/spruce_ab494436448fbb1d244833046ea6f6af1544e86d");
     cy.dataCy("restart-version").should("not.be.disabled");

--- a/cypress/integration/version/routes.ts
+++ b/cypress/integration/version/routes.ts
@@ -11,13 +11,6 @@ const versions = {
 const versionRoute = (id) => `/version/${id}`;
 
 describe("Version route", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   describe("Redirects", () => {
     it("Redirects to configure patch page if patch is not activated", () => {
       cy.visit(versionRoute(versions[3]));
@@ -62,7 +55,6 @@ describe("Version route", () => {
 
   describe("Build Variants", () => {
     before(() => {
-      cy.preserveCookies();
       cy.visit(versionRoute(versions[0]));
     });
 
@@ -184,7 +176,6 @@ describe("Version route", () => {
 
   describe("Page title", () => {
     before(() => {
-      cy.preserveCookies();
       cy.visit(versionRoute(versions[6]));
     });
     it("Should include a link to Jira", () => {

--- a/cypress/integration/version/schedule_modal.ts
+++ b/cypress/integration/version/schedule_modal.ts
@@ -1,10 +1,4 @@
 describe("Restarting and scheduling mainline commits", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("should be able to schedule inactive mainline commit tasks", () => {
     cy.visit("/version/spruce_e695f654c8b4b959d3e12e71696c3e318bcd4c33");
     cy.dataCy("schedule-patch").should("exist");

--- a/cypress/integration/version/subscription_modal.ts
+++ b/cypress/integration/version/subscription_modal.ts
@@ -7,14 +7,6 @@ describe("Version Subscription Modal", () => {
   const dataCyToggleModalButton = "notify-patch";
   const route = "/version/5e4ff3abe3c3317e352062e4/tasks";
 
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("Regex selector inputs", () => {
     it("Clicking on 'Add Additional Criteria' adds a regex selector row", () => {
       openSubscriptionModal(route, dataCyToggleModalButton);

--- a/cypress/integration/version/task_duration.ts
+++ b/cypress/integration/version/task_duration.ts
@@ -2,14 +2,6 @@ const patch = "5e4ff3abe3c3317e352062e4";
 const TASK_DURATION_ROUTE = `/version/${patch}/task-duration`;
 
 describe("Task Duration Tab", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("when interacting with the filters on the page", () => {
     it("updates URL appropriately when task name filter is applied", () => {
       cy.visit(TASK_DURATION_ROUTE);

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -1,5 +1,4 @@
 import { urlSearchParamsAreUpdated } from "../../utils";
-import { aliasQuery, GQL_URL } from "../../utils/graphql-test-utils";
 
 const patch = {
   id: "5e4ff3abe3c3317e352062e4",
@@ -56,7 +55,7 @@ describe("Tasks filters", () => {
         .find("input")
         .focus()
         .type(variantInputValue)
-        .type("{enter}");
+        .type("{enter}", { scrollBehavior: false });
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
@@ -68,7 +67,7 @@ describe("Tasks filters", () => {
         .find("input")
         .focus()
         .clear()
-        .type(`{enter}`);
+        .type(`{enter}`, { scrollBehavior: false });
       urlSearchParamsAreUpdated({
         pathname: pathTasks,
         paramName: urlParam,
@@ -159,7 +158,7 @@ describe("Tasks filters", () => {
         "Blocked",
       ];
       cy.toggleTableFilter(2);
-      cy.getInputByLabel("All").check({ force: true });
+      cy.getInputByLabel("All").check({ force: true, scrollBehavior: false });
       taskStatuses.forEach((status) => {
         cy.getInputByLabel(status).should("be.checked");
       });
@@ -168,7 +167,7 @@ describe("Tasks filters", () => {
         paramName: urlParam,
         search: "all",
       });
-      cy.getInputByLabel("All").uncheck({ force: true });
+      cy.getInputByLabel("All").uncheck({ force: true, scrollBehavior: false });
       taskStatuses.forEach((status) => {
         cy.getInputByLabel(status).should("not.be.checked");
       });
@@ -183,11 +182,8 @@ describe("Tasks filters", () => {
   describe("Task Base Statuses select", () => {
     const urlParam = "baseStatuses";
     before(() => {
-      cy.intercept("POST", GQL_URL, (req) => {
-        aliasQuery(req, "PatchTasks");
-      });
       cy.visit(pathTasks);
-      cy.wait("@gqlPatchTasksQuery");
+      cy.dataCy("tasks-table").should("be.visible");
       cy.toggleTableFilter(3);
     });
 
@@ -197,12 +193,15 @@ describe("Tasks filters", () => {
         .invoke("text")
         .then((preFilterCount) => {
           cy.getInputByLabel("Succeeded").check({ force: true });
-          cy.wait("@gqlPatchTasksQuery");
           urlSearchParamsAreUpdated({
             pathname: pathTasks,
             paramName: urlParam,
             search: "success",
           });
+          cy.dataCy("tasks-table").should("be.visible");
+          cy.dataCy("current-task-count")
+            .invoke("text")
+            .should("have.length.greaterThan", 0);
           cy.dataCy("current-task-count")
             .invoke("text")
             .then((postFilterCount) => {

--- a/cypress/integration/version/task_filters.ts
+++ b/cypress/integration/version/task_filters.ts
@@ -9,12 +9,6 @@ const pathURLWithFilters = `${pathTasks}?page=0&sorts=STATUS%3AASC%3BBASE_STATUS
 const defaultPath = `${pathTasks}?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC`;
 
 describe("Tasks filters", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   afterEach(() => {
     cy.dataCy("tasks-table").should("exist");
   });

--- a/cypress/integration/version/task_table.ts
+++ b/cypress/integration/version/task_table.ts
@@ -4,14 +4,6 @@ const pathTasks = `/version/5e4ff3abe3c3317e352062e4/tasks`;
 const patchDescriptionTasksExist = "dist";
 
 describe("Task table", () => {
-  before(() => {
-    cy.login();
-  });
-
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   it("Loading skeleton does not persist when you navigate to Patch page from My Patches and adjust a filter", () => {
     cy.visit("user/patches");
     cy.dataCy("patch-card-patch-link")
@@ -97,9 +89,7 @@ describe("Task table", () => {
     before(() => {
       cy.visit(pathTasks);
     });
-    beforeEach(() => {
-      cy.preserveCookies();
-    });
+
     // Instead of checking the entire table rows lets just check if the elements on the table have changed
     it("Displays the next page of results and updates URL when right arrow is clicked and next page exists", () => {
       cy.contains("test-cloud");

--- a/cypress/integration/version/unscheduled_patch/code_changes_table.ts
+++ b/cypress/integration/version/unscheduled_patch/code_changes_table.ts
@@ -6,9 +6,6 @@ describe("Code Changes Table", () => {
     cy.visit(`/version/${patchId}/changes`);
   });
 
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
   it("Should display at least one table when there are code changes", () => {
     cy.dataCy("code-changes-table").should("exist");
   });

--- a/cypress/integration/version/unscheduled_patch/configure_patch.ts
+++ b/cypress/integration/version/unscheduled_patch/configure_patch.ts
@@ -4,13 +4,6 @@ import { mockErrorResponse } from "../../../utils/mockErrorResponse";
 const unactivatedPatchId = "5e6bb9e23066155a993e0f1a";
 const patchWithDisplayTasks = "5e6bb9e23066155a993e0f1b";
 describe("Configure Patch Page", () => {
-  before(() => {
-    cy.login();
-  });
-  beforeEach(() => {
-    cy.preserveCookies();
-  });
-
   describe("Initial state reflects patch data", () => {
     before(() => {
       cy.visit(`/version/${unactivatedPatchId}`);

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -65,19 +65,6 @@ Cypress.Commands.add("toggleTableFilter", (colNum: number) => {
 });
 
 Cypress.Commands.add(
-  "paste",
-  { prevSubject: true },
-  (selector: Element, pastePayload: string) => {
-    // We can paste directly into a textarea but the onchange event is not fired because cypress directly manipulates the dom elements value.
-    // So we need to manually type in the last character of the paste payload to trigger an onchange event.
-    const subString = pastePayload.substr(0, pastePayload.length - 1);
-    const lastChar = pastePayload.slice(-1);
-    cy.wrap(selector).invoke("val", subString);
-    cy.wrap(selector).type(lastChar);
-  }
-);
-
-Cypress.Commands.add(
   "validateToast",
   (status: string, message?: string, shouldClose?: boolean) => {
     cy.dataCy(`toast`).should("be.visible");

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -78,17 +78,6 @@ declare global {
        * @example cy.toggleTableFilter(1)
        */
       toggleTableFilter(columnNumber: number): void;
-
-      /**
-       * Custom command to paste a value into an input
-       * Since this relies on a hack to paste a value on an input, it should be use sparingly
-       * only in situations when users would normally expect to be able to paste a value into an input eg. ssh-keys
-       * @param value The value to be pasted into the input
-       * @param input The input element to be pasted into
-       * @example cy.dataCy("some-input").paste("Some Value")
-       */
-      paste(value: string): void;
-
       /**
        * Custom command to validate a toast was rendered
        * @example cy.validateToast("success", "This succeeded")

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -105,3 +105,17 @@ declare global {
     }
   }
 }
+
+// Login before each test and remove banner cookies
+// We can disable the necessary cookies for tests that need the banners
+before(() => {
+  cy.login();
+});
+beforeEach(() => {
+  cy.setCookie(bannerCookie, "true");
+  cy.setCookie(slackBannerCookie, "true");
+  cy.preserveCookies();
+});
+
+const bannerCookie = "This is an important notification";
+const slackBannerCookie = "has-closed-slack-banner";

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "camelcase": "^6.1.0",
     "colors": "1.4.0",
     "css-loader": "4.3.0",
-    "cypress": "10.3.0",
+    "cypress": "10.3.1",
     "eslint": "8.19.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.17.12",
     "@babel/preset-react": "^7.12.13",
     "@bugsnag/source-maps": "^2.3.0",
-    "@cypress/webpack-preprocessor": "5.4.6",
     "@emotion/babel-plugin": "^11.1.2",
     "@emotion/jest": "^11.9.1",
     "@graphql-codegen/cli": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spruce",
-  "version": "2.36.18",
+  "version": "2.36.19",
   "private": true,
   "scripts": {
     "build-storybook": "build-storybook",

--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -75,10 +75,15 @@ export const SlackNotificationBanner = () => {
         },
       },
     });
+    hideBanner();
   };
 
+  // lets only show the banner if we have data for the user settings and the user has not closed the banner
+  // this prevents a flicker of the banner on initial load
   const hasSetNotifications =
-    isNotificationSet(patchFirstFailure) && isNotificationSet(patchFinish);
+    !notifications &&
+    (isNotificationSet(patchFirstFailure) || isNotificationSet(patchFinish));
+
   const showSlackBanner = !hasClosedBanner && !hasSetNotifications;
 
   return (

--- a/src/components/Banners/SlackNotificationBanner.tsx
+++ b/src/components/Banners/SlackNotificationBanner.tsx
@@ -78,7 +78,7 @@ export const SlackNotificationBanner = () => {
     hideBanner();
   };
 
-  // lets only show the banner if we have data for the user settings and the user has not closed the banner
+  // let's only show the banner if we have data for the user settings and the user has not closed the banner
   // this prevents a flicker of the banner on initial load
   const hasSetNotifications =
     !notifications &&

--- a/src/components/Header/AuxiliaryDropdown.tsx
+++ b/src/components/Header/AuxiliaryDropdown.tsx
@@ -21,7 +21,7 @@ export const AuxiliaryDropdown = () => {
   const projectCookie = Cookies.get(CURRENT_PROJECT);
 
   const { data } = useQuery<GetSpruceConfigQuery>(GET_SPRUCE_CONFIG, {
-    skip: !!projectCookie,
+    skip: projectCookie !== undefined,
   });
   const mostRecentProject =
     projectCookie || data?.spruceConfig?.ui?.defaultProject;

--- a/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
+++ b/src/pages/projectSettings/tabs/GeneralTab/getFormSchema.tsx
@@ -34,6 +34,7 @@ export const getFormSchema = (
       generalConfiguration: {
         type: "object" as "object",
         title: "General Configuration",
+        required: ["branch"],
         properties: {
           enabled: {
             type: ["boolean", "null"],
@@ -45,6 +46,7 @@ export const getFormSchema = (
           repositoryInfo: {
             type: "object" as "object",
             title: "Repository Info",
+            required: ["owner", "repo"],
             properties: {
               owner: {
                 type: "string" as "string",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,8 +39,15 @@ export default defineConfig({
           // Replace the variables in our HTML files.
           injectVariablesInHTML({
             files: "build/index.html",
-            from: ["%GIT_SHA%", "%RELEASE_STAGE%"],
-            to: [process.env.GIT_SHA, process.env.REACT_APP_RELEASE_STAGE],
+            variables: [
+              "%GIT_SHA%",
+              "%RELEASE_STAGE%",
+              "%REACT_APP_NEW_RELIC_ACCOUNT_ID%",
+              "%REACT_APP_NEW_RELIC_TRUST_KEY%",
+              "%REACT_APP_NEW_RELIC_AGENT_ID%",
+              "%REACT_APP_NEW_RELIC_LICENSE_KEY%",
+              "%REACT_APP_NEW_RELIC_APPLICATION_ID%",
+            ],
           }),
         ],
         manualChunks: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15070,15 +15070,10 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.24.0, moment@^2.27.0:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-moment@^2.29.2:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
-  integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
+moment@^2.24.0, moment@^2.27.0, moment@^2.29.2:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
 move-concurrently@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2567,15 +2567,6 @@
     tunnel-agent "^0.6.0"
     uuid "^8.3.2"
 
-"@cypress/webpack-preprocessor@5.4.6":
-  version "5.4.6"
-  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.6.tgz#667f8007cbe6ee219ce7e45a7f1400d3e2401032"
-  integrity sha512-78hWoTUUEncv647badwVbyszvmwI1r9GaY/xy7V0sz0VVC90ByuDkLpvN+J0VP6enthob4dIPXcm0f9Tb1UKQQ==
-  dependencies:
-    bluebird "^3.7.1"
-    debug "^4.1.1"
-    lodash "^4.17.20"
-
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -7652,7 +7643,7 @@ blob-util@^2.0.2:
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
   integrity sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
 
-bluebird@^3.5.5, bluebird@^3.7.1, bluebird@^3.7.2:
+bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9264,10 +9264,10 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypress@10.3.0:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.0.tgz#fae8d32f0822fcfb938e79c7c31ef344794336ae"
-  integrity sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==
+cypress@10.3.1:
+  version "10.3.1"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.3.1.tgz#7fab4ef43481c05a9a17ebe9a0ec860e15b95a19"
+  integrity sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==
   dependencies:
     "@cypress/request" "^2.88.10"
     "@cypress/xvfb" "^1.2.4"


### PR DESCRIPTION
Removes beforeEach login and replaces with a global hook.
Fix query waiting and use ui guards.
Fix banners showing everywhere.

Below are 3 test runs proving no flakes

https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_b410b82a2bd072d7a853eee3f9100ea8ce72eb3d_62e4405ba4cf47145100d277_22_07_29_20_17_36/tests?execution=0&sortBy=STATUS&sortDir=ASC

https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_b410b82a2bd072d7a853eee3f9100ea8ce72eb3d_62e441d757e85a400aa8b65d_22_07_29_20_23_59/tests?execution=0&sortBy=STATUS&sortDir=ASC


https://spruce.mongodb.com/task/spruce_ubuntu1604_e2e_test_patch_b410b82a2bd072d7a853eee3f9100ea8ce72eb3d_62e441d757e85a400aa8b65d_22_07_29_20_23_59

Final commit:
https://evergreen.mongodb.com/version/62e456f3562343662d8bebbd?redirect_spruce_users=true